### PR TITLE
Sage/streamlinejs#332 - typescript support + enabled ES6 import

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -355,7 +355,7 @@ module.exports = function(pluginArguments) {
 					var node = path.node;
 					var scope = path.scope;
 					if (!canTransform(state)) return;
-					if (is_(node) && !node.done) {
+					if (is_(node) && !node.done && !t.isImportSpecifier(path.parent)) {
 						throw path.buildCodeFrameError("unexpected _");
 					}
 				}
@@ -405,6 +405,12 @@ module.exports = function(pluginArguments) {
 					path.replaceWith(node);
 				}
 			},
+			ImportDeclaration: function(path, state) {
+				// enable streamline on .ts files if streamline-runtime is imported
+				if (path.node.source.value === 'streamline-runtime' && /\.ts$/.test(state.file.opts.filename)) {
+					state.streamline.forceTransform = true;
+				}
+			},
 			Function: function(path, state) {
 				var node = path.node;
 				var scope = path.scope;
@@ -413,14 +419,29 @@ module.exports = function(pluginArguments) {
 				if (!canTransform(state)) return;
 				var index;
 				if ((index = findIndex(node.params, is_)) >= 0) {
-					if (t.isFunctionDeclaration(node) && node.loc) throw path.buildCodeFrameError("nested function declaration");
+					var isExport = t.isExportDeclaration(path.parent);
+					if (t.isFunctionDeclaration(node) && node.loc && !isExport)
+						throw path.buildCodeFrameError("nested function declaration");
 					var param = node.params[index];
 					param.$done = true;
 					if (node.generator) throw path.buildCodeFrameError("parameter _ not allowed in generator function");
 					if (node.async) throw path.buildCodeFrameError("parameter _ not allowed: function already marked `async`");
-					path.replaceWith(streamlineFunction.call(this, t, state, node, scope, index));
+					var expr = streamlineFunction.call(this, t, state, node, scope, index);
+					if (isExport) {
+						var applyExpr = t.callExpression(
+							t.memberExpression(
+								expr,
+								t.identifier('apply')),
+							[t.thisExpression(), t.identifier('arguments')]);
+						expr = t.functionDeclaration(
+							node.id, 
+							node.params,
+							t.blockStatement([t.returnStatement(applyExpr)]),
+							node.generator, 
+							node.async);
+					}
+					path.replaceWith(expr);
 				}
-
 			},
 			CallExpression: function(path, state) {
 				var node = path.node;


### PR DESCRIPTION
This PR enables streamline on typescript files (`.ts`) as soon as the file contains an import like:

``` js
import { _ } from 'streamline-runtime'
```

This PR also fixes a bug with export of streamline functions:

``` js
export function foo(_, arg) { ... } // was failing before
```
